### PR TITLE
Improve armour details on drafing screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,49 +1,34 @@
-import React, { useReducer, useEffect } from 'react';
-import { RefreshCw, CheckCircle, XCircle, Users, Bug } from 'lucide-react';
-import { selectRandomEvent, EVENT_TYPES, EVENTS } from './systems/events/events';
-import { RARITY, TYPE } from './constants/types';
-import { MASTER_DB } from './data/itemsByWarbond';
-import { STARTING_LOADOUT, DIFFICULTY_CONFIG, getMissionsForDifficulty } from './constants/gameConfig';
-import { ARMOR_PASSIVE_DESCRIPTIONS } from './constants/armorPassives';
-import { getItemById } from './utils/itemHelpers';
-import { getDraftHandSize, getWeightedPool, generateDraftHand } from './utils/draftHelpers';
-import { areStratagemSlotsFull, getFirstEmptyStratagemSlot } from './utils/loadoutHelpers';
-import { getArmorComboDisplayName } from './utils/itemHelpers';
-import { getItemIconUrl } from './utils/iconHelpers';
-import { processAllOutcomes, canAffordChoice, formatOutcome, formatOutcomes, needsPlayerChoice, applyGainBoosterWithSelection } from './systems/events/eventProcessor';
-import { exportGameStateToFile, parseSaveFile, normalizeLoadedState } from './systems/persistence/saveManager';
-import GameHeader from './components/GameHeader';
-import GameFooter from './components/GameFooter';
-import EventDisplay from './components/EventDisplay';
-import LoadoutDisplay from './components/LoadoutDisplay';
-import GameLobby from './components/GameLobby';
-import GameConfiguration from './components/GameConfiguration';
-import RarityWeightDebug from './components/RarityWeightDebug';
-import ExplainerModal from './components/ExplainerModal';
-import PatchNotesModal from './components/PatchNotesModal';
-import GenAIDisclosureModal from './components/GenAIDisclosureModal';
+import { Bug, CheckCircle, RefreshCw, Users, XCircle } from 'lucide-react';
+import React, { useEffect, useReducer } from 'react';
 import ContributorsModal from './components/ContributorsModal';
-import { MultiplayerModeSelect, JoinGameScreen, MultiplayerWaitingRoom, MultiplayerStatusBar } from './components/MultiplayerLobby';
-import { MultiplayerProvider, useMultiplayer } from './systems/multiplayer';
-import { gameReducer, initialState } from './state/gameReducer';
+import EventDisplay from './components/EventDisplay';
+import ExplainerModal from './components/ExplainerModal';
+import GameConfiguration from './components/GameConfiguration';
+import GameFooter from './components/GameFooter';
+import GameHeader from './components/GameHeader';
+import GameLobby from './components/GameLobby';
+import GenAIDisclosureModal from './components/GenAIDisclosureModal';
+import LoadoutDisplay from './components/LoadoutDisplay';
+import { JoinGameScreen, MultiplayerModeSelect, MultiplayerStatusBar, MultiplayerWaitingRoom } from './components/MultiplayerLobby';
+import PatchNotesModal from './components/PatchNotesModal';
+import RarityWeightDebug from './components/RarityWeightDebug';
+import { ARMOR_PASSIVE_DESCRIPTIONS } from './constants/armorPassives';
+import { DIFFICULTY_CONFIG, getMissionsForDifficulty, STARTING_LOADOUT } from './constants/gameConfig';
+import { BUTTON_STYLES, COLORS, getFactionColors, GRADIENTS, SHADOWS } from './constants/theme';
+import { RARITY, TYPE } from './constants/types';
+import { getWarbondById } from './constants/warbonds';
+import { MASTER_DB } from './data/itemsByWarbond';
 import * as actions from './state/actions';
 import * as types from './state/actionTypes';
-import { COLORS, SHADOWS, BUTTON_STYLES, GRADIENTS, getFactionColors } from './constants/theme';
-import { getWarbondById } from './constants/warbonds';
-
-// --- DATA CONSTANTS (imported from modules) ---
-
-
-
-
-
-
-
-
-
-// --- INITIAL STATE & HELPER LOGIC ---
-
-
+import { gameReducer, initialState } from './state/gameReducer';
+import { applyGainBoosterWithSelection, canAffordChoice, formatOutcome, formatOutcomes, needsPlayerChoice, processAllOutcomes } from './systems/events/eventProcessor';
+import { EVENT_TYPES, EVENTS, selectRandomEvent } from './systems/events/events';
+import { MultiplayerProvider, useMultiplayer } from './systems/multiplayer';
+import { exportGameStateToFile, normalizeLoadedState, parseSaveFile } from './systems/persistence/saveManager';
+import { generateDraftHand, getDraftHandSize, getWeightedPool } from './utils/draftHelpers';
+import { getItemIconUrl } from './utils/iconHelpers';
+import { getArmorComboDisplayName, getItemById } from './utils/itemHelpers';
+import { areStratagemSlotsFull, getFirstEmptyStratagemSlot } from './utils/loadoutHelpers';
 
 function HelldiversRoguelikeApp() {
   // --- STATE (Using useReducer for complex state management) ---
@@ -1181,9 +1166,10 @@ function HelldiversRoguelikeApp() {
       : item.name;
 
     let armorPassiveDescription = null;
+    let armorPassiveKey = null;
     const isArmorItem = isArmorCombo || item?.type === TYPE.ARMOR;
     if (isArmorItem) {
-      const armorPassiveKey = item.passive;
+      armorPassiveKey = item.passive;
       if (armorPassiveKey) {
         const description = ARMOR_PASSIVE_DESCRIPTIONS[armorPassiveKey];
         if (!description && process.env.NODE_ENV === 'development') {
@@ -1199,6 +1185,13 @@ function HelldiversRoguelikeApp() {
     const isSuperstore = displayItem.superstore;
     const warbondInfo = warbondId ? getWarbondById(warbondId) : null;
     const sourceName = isSuperstore ? 'Superstore' : (warbondInfo?.name || 'Unknown');
+    const tags = displayItem.tags || [];
+
+    // Show armor class in tags
+    const armorClass = item.armorClass ? item.armorClass.slice(0, 1).toUpperCase() + item.armorClass.slice(1) : null;
+    if (armorClass && !tags.includes(armorClass)) {
+      tags.push(armorClass);
+    }
     
     // Get item icon URL - use helper function
     const iconUrl = getItemIconUrl(displayItem);
@@ -1337,7 +1330,7 @@ function HelldiversRoguelikeApp() {
             {armorPassiveDescription && (
               <div style={{ marginTop: '10px' }}>
                 <div style={{ color: '#94a3b8', fontSize: '9px', textTransform: 'uppercase', letterSpacing: '1px' }}>
-                  Armor Passive
+                  Armor Passive - {armorPassiveKey}
                 </div>
                 <div style={{ color: '#cbd5e1', fontSize: '11px', lineHeight: '1.4', marginTop: '4px' }}>
                   {armorPassiveDescription}

--- a/src/constants/armorPassives.js
+++ b/src/constants/armorPassives.js
@@ -44,34 +44,36 @@ export const ARMOR_PASSIVE = {
   REINFORCED_EPAULETTES: 'reinforced_epaulettes',
   ADRENO_DEFIBRILLATOR: 'adreno_defibrillator',
   FEET_FIRST: 'feet_first',
+  REDUCED_SIGNATURE: 'reduced_signature',
 };
 
 // Passive descriptions for reference - flavour text from Helldivers wiki
 export const ARMOR_PASSIVE_DESCRIPTIONS = {
-  [ARMOR_PASSIVE.SERVO_ASSISTED]: '+30% throwing range, +50% limb health',
-  [ARMOR_PASSIVE.SCOUT]: 'Markers ping radar every 2 seconds, -30% enemy detection range',
-  [ARMOR_PASSIVE.PEAK_PHYSIQUE]: '+100% melee damage, reduced weapon sway when moving',
-  [ARMOR_PASSIVE.EXTRA_PADDING]: '+50 armor rating',
+  [ARMOR_PASSIVE.SERVO_ASSISTED]: 'Increases throwing range by 30%. Provides +50% limb health.',
+  [ARMOR_PASSIVE.SCOUT]: 'Markers placed on the map will generate radar scans every 2.0s. Reduces range at which enemies can detect the wearer by 30%.',
+  [ARMOR_PASSIVE.PEAK_PHYSIQUE]: 'Increases melee damage by 100%. Improves weapons handling with less drag on weapon movement.',
+  [ARMOR_PASSIVE.EXTRA_PADDING]: 'Provides a higher armor rating.',
   
-  [ARMOR_PASSIVE.FORTIFIED]: '50% explosive resistance, -30% recoil when crouching or prone',
-  [ARMOR_PASSIVE.DEMOCRACY_PROTECTS]: '50% chance to survive lethal damage, prevents chest bleed damage',
-  [ARMOR_PASSIVE.UNFLINCHING]: 'Reduced flinch when damaged, +25 armor, pings enemies on minimap',
-  [ARMOR_PASSIVE.BALLISTIC_PADDING]: '+25% chest and explosive resistance, prevents chest bleed damage',
-  [ARMOR_PASSIVE.ROCK_SOLID]: '-30% recoil when crouching or prone, +2 grenade capacity',
+  [ARMOR_PASSIVE.FORTIFIED]: 'Further reduces recoil when crouching or prone by 30%. Provides 50% resistance to explosive damage.',
+  [ARMOR_PASSIVE.DEMOCRACY_PROTECTS]: '50% chance to not die when taking lethal damage. Prevents all damage from bleeding if chest hemorrhages.',
+  [ARMOR_PASSIVE.UNFLINCHING]: 'Helps prevent Helldivers from flinching when hit. Provides a higher armor rating. Markers placed on the map will generate radar scans every 2.0s.',
+  [ARMOR_PASSIVE.BALLISTIC_PADDING]: 'Provides 25% resistance to chest damage. Provides 25% resistance to explosive damage. Prevents all damage from bleeding if chest hemorrhages.',
+  [ARMOR_PASSIVE.ROCK_SOLID]: 'Helps prevent Helldivers from ragdolling when hit. Increases melee damage by 100%.',
   
-  [ARMOR_PASSIVE.ENGINEERING_KIT]: '-30% recoil when crouching or prone, +2 grenade capacity',
-  [ARMOR_PASSIVE.MED_KIT]: '+2 stim capacity, +2 seconds stim duration',
-  [ARMOR_PASSIVE.ELECTRICAL_CONDUIT]: '95% arc damage resistance, reduced stun buildup',
+  [ARMOR_PASSIVE.ENGINEERING_KIT]: 'Further reduces recoil when crouching or prone by 30%. Increases initial inventory and holding capacity of throwables by +2.',
+  [ARMOR_PASSIVE.MED_KIT]: 'Increases initial inventory and holding capacity of stims by +2. Increases stim effect duration by 2.0s.',
+  [ARMOR_PASSIVE.ELECTRICAL_CONDUIT]: 'Provides 95% resistance to arc damage.',
   
-  [ARMOR_PASSIVE.INFLAMMABLE]: '75% fire damage resistance',
-  [ARMOR_PASSIVE.ADVANCED_FILTRATION]: '80% gas damage resistance',
-  [ARMOR_PASSIVE.DESERT_STORMER]: '95% acid damage resistance',
-  [ARMOR_PASSIVE.ACCLIMATED]: '50% resistance to fire, gas, acid, and electrical damage',
+  [ARMOR_PASSIVE.INFLAMMABLE]: 'Provides 75% damage resistance to fire, allowing bearer to rest assured in their inflammability.',
+  [ARMOR_PASSIVE.ADVANCED_FILTRATION]: 'Provides 80% resistance to gas damage and effects.',
+  [ARMOR_PASSIVE.DESERT_STORMER]: 'Provides 40% resistance to fire, gas, acid, and electrical damage. Increases throwing range by 20%.',
+  [ARMOR_PASSIVE.ACCLIMATED]: 'Provides 50% resistance to fire, gas, acid, and electrical damage.',
   
-  [ARMOR_PASSIVE.INTEGRATED_EXPLOSIVES]: 'Explodes on death, +2 grenade capacity',
-  [ARMOR_PASSIVE.GUNSLINGER]: '+40% sidearm reload speed, +50% draw/holster speed, -70% sidearm recoil',
-  [ARMOR_PASSIVE.SIEGE_READY]: '+20% primary ammo capacity, +30% primary reload speed',
-  [ARMOR_PASSIVE.REINFORCED_EPAULETTES]: '50% chance to prevent limb breaks',
-  [ARMOR_PASSIVE.ADRENO_DEFIBRILLATOR]: 'Revives after death, 50% arc resistance, +2s stim duration',
-  [ARMOR_PASSIVE.FEET_FIRST]: 'Prevents major leg injuries, +30% radar detection, -50% movement sound',
+  [ARMOR_PASSIVE.INTEGRATED_EXPLOSIVES]: 'Armor explodes 1.5s after the wearer dies. Increases initial inventory and holding capacity of throwables by +2.',
+  [ARMOR_PASSIVE.GUNSLINGER]: 'Increases sidearms reload speed by 40%. Sidearm draw/holster speed increased by 50%. Sidearm recoil reduced by 70%.',
+  [ARMOR_PASSIVE.SIEGE_READY]: 'Increases reload speed of primary weapons by 30%. Increases ammo capacity of all weapons by 20%. Does not affect weapon backpacks.',
+  [ARMOR_PASSIVE.REINFORCED_EPAULETTES]: 'Increases reload speed of primary weapons by 30%. Gives wearer a 50% chance to avoid grievous limb injury. Increases melee damage by 50%.',
+  [ARMOR_PASSIVE.ADRENO_DEFIBRILLATOR]: 'Provides one-time, short-lived resuscitation upon death, given that the Helldiver\'s body is still intact. Increases stim effect duration by 2.0s. Provides 50% resistance to arc damage.',
+  [ARMOR_PASSIVE.FEET_FIRST]: 'Wearer makes 50% less noise when moving. Increases point-of-interest identification range by 30%. Provides immunity to leg injuries.',
+  [ARMOR_PASSIVE.REDUCED_SIGNATURE]: "Wearer makes 50% less noise when moving. Reduces range at which enemies can detect the wearer by 40%."
 };

--- a/src/data/itemsByWarbond.js
+++ b/src/data/itemsByWarbond.js
@@ -1,5 +1,5 @@
-import { RARITY, TYPE, TAGS } from '../constants/types';
-import { ARMOR_PASSIVE, ARMOR_CLASS } from '../constants/armorPassives';
+import { ARMOR_CLASS, ARMOR_PASSIVE } from '../constants/armorPassives';
+import { RARITY, TAGS, TYPE } from '../constants/types';
 
 // This file organizes items by their source warbond for maintainability
 // Items without a warbond field default to 'helldivers_mobilize' (base game)


### PR DESCRIPTION
* Add exact description of the armor passives.
* Show the armor class and the armor passive name on the drafting screen.
* Tidy up a bit.

Resolves #96