### PR TITLE
Rename master to main and set up contributor rules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages and Firebase
 on:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - develop
-      - master
+      - main
 
 jobs:
   test:

--- a/BRANCH_SETUP.md
+++ b/BRANCH_SETUP.md
@@ -5,12 +5,12 @@ This guide documents how to set up the `develop` branch and configure branch pro
 ## Overview
 
 **Branch Strategy:**
-- **`master`** — Production branch. Auto-deploys to GitHub Pages when updated. Protected.
+- **`main`** — Production branch. Auto-deploys to GitHub Pages when updated. Protected.
 - **`develop`** — Integration branch for community contributions. All PRs target this branch.
 
 **Deployment Flow:**
 ```
-Contributor fork → PR to develop → Approved & merged → Maintainer merges develop → master → Auto-deploy
+Contributor fork → PR to develop → Approved & merged → Maintainer merges develop → main → Auto-deploy
 ```
 
 ## Step 1: Create the `develop` Branch
@@ -18,11 +18,11 @@ Contributor fork → PR to develop → Approved & merged → Maintainer merges d
 Run these commands locally:
 
 ```bash
-# Ensure you're on the latest master
-git checkout master
-git pull origin master
+# Ensure you're on the latest main
+git checkout main
+git pull origin main
 
-# Create develop branch from master
+# Create develop branch from main
 git checkout -b develop
 
 # Push develop to GitHub
@@ -39,10 +39,10 @@ git push -u origin develop
 
 **Why?** New contributors will automatically target `develop` when creating PRs, and the repo will display `develop` as the main branch.
 
-## Step 3: Configure `master` Branch Protection
+## Step 3: Configure `main` Branch Protection
 
 1. Go to **Settings** → **Branches** → **Add rule**
-2. **Branch name pattern:** `master`
+2. **Branch name pattern:** `main`
 3. Enable these rules:
 
 ### Required Settings
@@ -124,10 +124,10 @@ git push -u origin develop
 
 ## Step 5: Verify Workflows Run on PRs
 
-The [pr-check.yml](.github/workflows/pr-check.yml) workflow will automatically run on all PRs to `develop` and `master`. After the first PR is submitted:
+The [pr-check.yml](.github/workflows/pr-check.yml) workflow will automatically run on all PRs to `develop` and `main`. After the first PR is submitted:
 
 1. Go to **Settings** → **Branches**
-2. Edit the `master` and `develop` branch rules
+2. Edit the `main` and `develop` branch rules
 3. Under "Require status checks to pass before merging," search for and add:
    - `test` (the job name from pr-check.yml)
 
@@ -163,34 +163,34 @@ Once setup is complete:
 
 ## Ongoing Maintenance
 
-### Merging `develop` → `master`
+### Merging `develop` → `main`
 
 When you're ready to deploy changes from `develop`:
 
 ```bash
-git checkout master
-git pull origin master
+git checkout main
+git pull origin main
 git merge develop
-git push origin master
+git push origin main
 ```
 
 The [deploy.yml](.github/workflows/deploy.yml) workflow will automatically build and deploy to GitHub Pages.
 
 ### Keeping `develop` in Sync
 
-Periodically sync `develop` with `master` if hotfixes are made directly to `master`:
+Periodically sync `develop` with `main` if hotfixes are made directly to `main`:
 
 ```bash
 git checkout develop
-git merge master
+git merge main
 git push origin develop
 ```
 
-**Best practice:** Avoid committing directly to `master`. Always merge through `develop` → `master`.
+**Best practice:** Avoid committing directly to `main`. Always merge through `develop` → `main`.
 
 ## Summary of Branch Protection Rules
 
-| Rule | `master` | `develop` | Reason |
+| Rule | `main` | `develop` | Reason |
 |------|----------|-----------|--------|
 | Require PR | ✅ (1 approval) | ✅ (1 approval) | Code review required |
 | Require status checks | ✅ | ✅ | Lint, test, build must pass |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
 
 ### Branch Strategy
 
-- **`master`** — Production branch. Automatically deploys to GitHub Pages when updated. **Do not submit PRs directly to master.**
+- **`main`** — Production branch. Automatically deploys to GitHub Pages when updated. **Do not submit PRs directly to main.**
 - **`develop`** — Integration branch for all contributions. **Submit your PRs here.**
 
 ### Making Changes

--- a/src/utils/draftHelpers.test.js
+++ b/src/utils/draftHelpers.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable jest/no-conditional-expect */
 import { getDraftHandSize, getWeightedPool, generateDraftHand, generateRandomDraftOrder } from './draftHelpers';
-import { TYPE, FACTION, TAGS, RARITY } from '../constants/types';
-import { MASTER_DB, SUPERSTORE_ITEMS } from '../data/itemsByWarbond';
+import { TYPE, FACTION, TAGS } from '../constants/types';
+import { SUPERSTORE_ITEMS } from '../data/itemsByWarbond';
 
 describe('Utils - Draft Helpers', () => {
   describe('generateRandomDraftOrder', () => {


### PR DESCRIPTION
This pull request updates the repository's branch naming strategy from `master` to `main` throughout the codebase and documentation to align with modern Git conventions. It also ensures that CI/CD workflows and contributor guidelines consistently reference the new branch name.

**Branch Naming Strategy Updates:**

* Updated all references from `master` to `main` in the branch setup documentation, including branch protection rules, deployment flow, and maintenance instructions in `BRANCH_SETUP.md`. [[1]](diffhunk://#diff-fb2405690262c9d2e3698ca576e4c2def04ca1324961cd3f8bf52c0077a5b775L8-R25) [[2]](diffhunk://#diff-fb2405690262c9d2e3698ca576e4c2def04ca1324961cd3f8bf52c0077a5b775L42-R45) [[3]](diffhunk://#diff-fb2405690262c9d2e3698ca576e4c2def04ca1324961cd3f8bf52c0077a5b775L127-R130) [[4]](diffhunk://#diff-fb2405690262c9d2e3698ca576e4c2def04ca1324961cd3f8bf52c0077a5b775L166-R193)
* Changed the branch name in contributor guidelines in `CONTRIBUTING.md` to reflect `main` as the production branch.

**Workflow Configuration:**

* Updated the target branch for deploy and PR-check GitHub Actions workflows from `master` to `main` in `.github/workflows/deploy.yml` and `.github/workflows/pr-check.yml`. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L6-R6) [[2]](diffhunk://#diff-e76e5134b85a9eb3e0d9ce8e671ce97c8c577ff3c24162c45d71691078201347L7-R7)

**Code Maintenance:**

* Removed unused `MASTER_DB` import from `src/utils/draftHelpers.test.js` to clean up test dependencies.