### PR TITLE
Add GitHub Actions workflow to automate release PR creation from deve…

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,82 @@
+name: Create Release PR
+
+on:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for existing release PR
+        id: check-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if a PR from develop to main already exists
+          EXISTING_PR=$(gh pr list --base main --head develop --state open --json number --jq '.[0].number')
+          
+          if [ -n "$EXISTING_PR" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "pr_number=$EXISTING_PR" >> $GITHUB_OUTPUT
+            echo "✅ Release PR #$EXISTING_PR already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "❌ No release PR found"
+          fi
+
+      - name: Create release PR
+        if: steps.check-pr.outputs.exists == 'false'
+        id: create-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Generate PR body with commits since last merge to main
+          LAST_RELEASE=$(git log main --oneline -1 --pretty=format:"%h")
+          COMMITS=$(git log main..develop --oneline --pretty=format:"- %s (%h)" | head -20)
+          
+          PR_BODY="## 🚀 Release from develop to main
+
+This PR contains changes ready for deployment to production.
+
+### Recent Changes
+$COMMITS
+
+---
+**Note:** This PR was automatically created when changes were merged to \`develop\`.
+Review the changes and merge when ready to deploy to production."
+
+          # Create the PR
+          PR_NUMBER=$(gh pr create \
+            --base main \
+            --head develop \
+            --title "🚀 Release: Deploy develop to main" \
+            --body "$PR_BODY" \
+            --label "release" \
+            | grep -oP '(?<=pull/)\d+')
+          
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "✅ Created release PR #$PR_NUMBER"
+
+      - name: Add reviewers
+        if: steps.check-pr.outputs.exists == 'false' && steps.create-pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.create-pr.outputs.pr_number }}"
+          
+          # Add reviewers
+          gh pr edit $PR_NUMBER --add-reviewer TheInsomnolent,James-Archer
+          
+          echo "✅ Added reviewers to PR #$PR_NUMBER"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the creation of release pull requests from the `develop` branch to the `main` branch. This workflow streamlines the release process by checking for existing release PRs, creating a new PR if needed, summarizing recent commits, and assigning reviewers automatically.

**Release PR automation:**

* Added `.github/workflows/release-pr.yml` to create a release pull request from `develop` to `main` whenever changes are pushed to `develop`.
* The workflow checks for an existing open release PR and only creates a new one if none exists, preventing duplicate PRs.
* Automatically generates a PR body listing recent commits from `develop` since the last merge to `main` for better visibility.
* Assigns reviewers (`TheInsomnolent`, `James-Archer`) to the newly created release PR to ensure timely review and deployment.