### PR TITLE
take 2

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -46,26 +46,24 @@ jobs:
           LAST_RELEASE=$(git log main --oneline -1 --pretty=format:"%h")
           COMMITS=$(git log main..develop --oneline --pretty=format:"- %s (%h)" | head -20)
           
-          PR_BODY="## 🚀 Release from develop to main
-
-This PR contains changes ready for deployment to production.
-
-### Recent Changes
-$COMMITS
-
----
-**Note:** This PR was automatically created when changes were merged to \`develop\`.
-Review the changes and merge when ready to deploy to production."
-
-          # Create the PR
-          PR_NUMBER=$(gh pr create \
+          # Create the PR with multiline body
+          gh pr create \
             --base main \
             --head develop \
             --title "🚀 Release: Deploy develop to main" \
-            --body "$PR_BODY" \
-            --label "release" \
-            | grep -oP '(?<=pull/)\d+')
+            --body "## 🚀 Release from develop to main
+
+          This PR contains changes ready for deployment to production.
+
+          ### Recent Changes
+          $COMMITS
+
+          ---
+          **Note:** This PR was automatically created when changes were merged to \`develop\`.
+          Review the changes and merge when ready to deploy to production." \
+            --label "release" > pr_output.txt
           
+          PR_NUMBER=$(cat pr_output.txt | grep -oP '(?<=pull/)\d+')
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "✅ Created release PR #$PR_NUMBER"
 


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release-pr.yml` to improve how release pull requests are created and handled. The main change is refactoring the PR creation step to use a more robust approach for passing multiline body content and capturing the PR number.

**Workflow improvements:**

* Refactored the pull request creation command to directly use `gh pr create` with a multiline body, eliminating the need for a separate variable to hold the PR body.
* Changed the method for extracting the pull request number by saving the output of the PR creation command to a file (`pr_output.txt`) and parsing it, which improves reliability and readability.