### PR TITLE
Add step to fetch main branch in release PR workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch main branch
+        run: |
+          git fetch origin main:main || echo "main branch may not exist yet"
+
       - name: Check for existing release PR
         id: check-pr
         env:


### PR DESCRIPTION
This pull request introduces a minor update to the release workflow by ensuring the `main` branch is available during the process. This helps prevent issues when referencing the `main` branch in subsequent steps.

* Workflow improvement:
  * Added a step to fetch the `main` branch in `.github/workflows/release-pr.yml` to ensure it is available, handling cases where it may not exist yet.