### PR TITLE
fix: limit mission star rating based on difficulty level

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5919,60 +5919,74 @@ function HelldiversRoguelikeApp() {
                                     pointerEvents: !isMultiplayer || isHost ? 'auto' : 'none',
                                 }}
                             >
-                                {[1, 2, 3, 4, 5].map((n) => (
-                                    <button
-                                        key={n}
-                                        onClick={() =>
-                                            dispatch(actions.updateGameConfig({ starRating: n }))
-                                        }
-                                        disabled={isMultiplayer && !isHost}
-                                        style={{
-                                            padding: '16px 8px',
-                                            borderRadius: '4px',
-                                            fontWeight: '900',
-                                            fontSize: '24px',
-                                            display: 'flex',
-                                            flexDirection: 'column',
-                                            alignItems: 'center',
-                                            justifyContent: 'center',
-                                            transition: 'all 0.2s',
-                                            backgroundColor:
-                                                gameConfig.starRating === n
-                                                    ? factionColors.PRIMARY
-                                                    : 'transparent',
-                                            color:
-                                                gameConfig.starRating === n ? 'black' : '#64748b',
-                                            border:
-                                                gameConfig.starRating === n
-                                                    ? `2px solid ${factionColors.PRIMARY}`
-                                                    : '1px solid rgba(100, 116, 139, 0.5)',
-                                            cursor:
-                                                !isMultiplayer || isHost
-                                                    ? 'pointer'
-                                                    : 'not-allowed',
-                                        }}
-                                        onMouseEnter={(e) => {
-                                            if (
-                                                gameConfig.starRating !== n &&
-                                                (!isMultiplayer || isHost)
-                                            ) {
-                                                e.currentTarget.style.borderColor = '#64748b'
+                                {[1, 2, 3, 4, 5].map((n) => {
+                                    // Calculate max allowed stars based on current difficulty
+                                    // D1-D2: max 2 stars, D3-D4: max 3 stars, D5-D6: max 4 stars, D7+: max 5 stars
+                                    const getMaxStarsForDifficulty = (diff) => {
+                                        if (diff <= 2) return 2
+                                        if (diff <= 4) return 3
+                                        if (diff <= 6) return 4
+                                        return 5
+                                    }
+
+                                    const maxStars = getMaxStarsForDifficulty(currentDiff)
+                                    const isDisabled = n > maxStars || (isMultiplayer && !isHost)
+
+                                    return (
+                                        <button
+                                            key={n}
+                                            onClick={() =>
+                                                !isDisabled &&
+                                                dispatch(
+                                                    actions.updateGameConfig({ starRating: n }),
+                                                )
                                             }
-                                        }}
-                                        onMouseLeave={(e) => {
-                                            if (
-                                                gameConfig.starRating !== n &&
-                                                (!isMultiplayer || isHost)
-                                            ) {
-                                                e.currentTarget.style.borderColor =
-                                                    'rgba(100, 116, 139, 0.5)'
-                                            }
-                                        }}
-                                    >
-                                        <div>{n}</div>
-                                        <div style={{ fontSize: '16px' }}>★</div>
-                                    </button>
-                                ))}
+                                            disabled={isDisabled}
+                                            style={{
+                                                padding: '16px 8px',
+                                                borderRadius: '4px',
+                                                fontWeight: '900',
+                                                fontSize: '24px',
+                                                display: 'flex',
+                                                flexDirection: 'column',
+                                                alignItems: 'center',
+                                                justifyContent: 'center',
+                                                transition: 'all 0.2s',
+                                                backgroundColor:
+                                                    gameConfig.starRating === n
+                                                        ? factionColors.PRIMARY
+                                                        : 'transparent',
+                                                color: isDisabled
+                                                    ? '#334155'
+                                                    : gameConfig.starRating === n
+                                                      ? 'black'
+                                                      : '#64748b',
+                                                border:
+                                                    gameConfig.starRating === n
+                                                        ? `2px solid ${factionColors.PRIMARY}`
+                                                        : isDisabled
+                                                          ? '1px solid #1e293b'
+                                                          : '1px solid rgba(100, 116, 139, 0.5)',
+                                                cursor: isDisabled ? 'not-allowed' : 'pointer',
+                                                opacity: isDisabled ? 0.4 : 1,
+                                            }}
+                                            onMouseEnter={(e) => {
+                                                if (!isDisabled && gameConfig.starRating !== n) {
+                                                    e.currentTarget.style.borderColor = '#64748b'
+                                                }
+                                            }}
+                                            onMouseLeave={(e) => {
+                                                if (!isDisabled && gameConfig.starRating !== n) {
+                                                    e.currentTarget.style.borderColor =
+                                                        'rgba(100, 116, 139, 0.5)'
+                                                }
+                                            }}
+                                        >
+                                            <div>{n}</div>
+                                            <div style={{ fontSize: '16px' }}>★</div>
+                                        </button>
+                                    )
+                                })}
                             </div>
                             <p
                                 style={{


### PR DESCRIPTION
Closes #128

This PR fixes the bug where low difficulty missions could be submitted with improperly high star ratings.

**Changes:**
- Added `getMaxStarsForDifficulty()` function to calculate max allowed stars
- D1-D2 missions now limited to 2 stars maximum
- D3-D4 missions limited to 3 stars maximum
- D5-D6 missions limited to 4 stars maximum
- D7+ missions allow full 5 stars
- Disabled star buttons show visual feedback (reduced opacity, disabled cursor)
- Maintains existing multiplayer host-only restriction

**Testing:**
- Validated that star buttons are properly disabled based on difficulty
- Confirmed visual feedback works correctly
- Multiplayer restrictions still function as expected
