### PR TITLE
Add PUBLIC_URL environment variable for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           REACT_APP_BUILD_TIME: ${{ github.event.head_commit.timestamp }}
           REACT_APP_COMMIT_SHA: ${{ github.sha }}
+          PUBLIC_URL: /helldrafters/branch-${{ steps.sanitize.outputs.safe }}
 
       - name: Sanitize branch name for directory
         id: sanitize
@@ -77,19 +78,19 @@ jobs:
           BRANCH="${{ steps.branch.outputs.name }}"
           SAFE_NAME="${{ steps.sanitize.outputs.safe }}"
           DEPLOY_URL="https://theinsomnolent.github.io/helldrafters/branch-$SAFE_NAME/"
-          
+
           # Try to find an open PR for this branch
           PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' || echo "")
-          
+
           if [ -n "$PR_NUMBER" ]; then
             echo "Found PR #$PR_NUMBER for branch $BRANCH"
-            
+
             # Post comment with deployment URL
             gh pr comment $PR_NUMBER --body "🚀 **Test deployment available!**
-          
+
           Branch \`$BRANCH\` has been deployed to:
           $DEPLOY_URL
-          
+
           This deployment will be automatically cleaned up when:
           - This PR is merged or closed
           - A new build is pushed to \`main\` or \`develop\`"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           REACT_APP_BUILD_TIME: ${{ github.event.head_commit.timestamp }}
           REACT_APP_COMMIT_SHA: ${{ github.sha }}
+          PUBLIC_URL: ${{ github.ref == 'refs/heads/develop' && '/helldrafters/develop' || '/helldrafters' }}
 
       - name: Determine deployment directory
         id: deploy-dir
@@ -69,10 +70,10 @@ jobs:
         run: |
           git fetch origin gh-pages:gh-pages
           git checkout gh-pages
-          
+
           # Enable nullglob to handle case where no matches exist
           shopt -s nullglob
-          
+
           # Remove all directories that look like test deployments (pr-* or branch-*)
           for dir in pr-* branch-*; do
             if [ -d "$dir" ]; then
@@ -80,7 +81,7 @@ jobs:
               git rm -rf "$dir"
             fi
           done
-          
+
           # Commit and push if there were changes
           if git diff --cached --quiet; then
             echo "No test deployments to clean up"


### PR DESCRIPTION
This pull request updates the deployment workflow configuration to ensure the correct `PUBLIC_URL` is set for different deployment environments. The changes improve how the application determines its base URL depending on the branch being deployed.

**Deployment workflow improvements:**

* In `.github/workflows/deploy-test.yml`, added logic to set `PUBLIC_URL` based on the sanitized branch name, ensuring test deployments are served from the correct subdirectory.
* In `.github/workflows/deploy.yml`, updated `PUBLIC_URL` to dynamically choose the appropriate path for the `develop` branch versus other branches, streamlining production and development deployments.