### PR TITLE
Fix test ci issue

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -42,6 +42,15 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
+      - name: Sanitize branch name for directory
+        id: sanitize
+        run: |
+          BRANCH="${{ steps.branch.outputs.name }}"
+          # Replace slashes and other special chars with dashes
+          SAFE_NAME=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
+          echo "safe=$SAFE_NAME" >> $GITHUB_OUTPUT
+          echo "Sanitized branch name: $SAFE_NAME"
+
       - name: Copy CHANGELOG to build
         run: |
           echo "Copying CHANGELOG.md to public folder for deployment"
@@ -53,15 +62,6 @@ jobs:
           REACT_APP_BUILD_TIME: ${{ github.event.head_commit.timestamp }}
           REACT_APP_COMMIT_SHA: ${{ github.sha }}
           PUBLIC_URL: /helldrafters/branch-${{ steps.sanitize.outputs.safe }}
-
-      - name: Sanitize branch name for directory
-        id: sanitize
-        run: |
-          BRANCH="${{ steps.branch.outputs.name }}"
-          # Replace slashes and other special chars with dashes
-          SAFE_NAME=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
-          echo "safe=$SAFE_NAME" >> $GITHUB_OUTPUT
-          echo "Sanitized branch name: $SAFE_NAME"
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
This pull request makes a minor adjustment to the deployment workflow by moving the branch name sanitization step earlier in the process. This ensures the sanitized branch name is available before setting environment variables for the deployment.

- Workflow improvement:
  * Moved the "Sanitize branch name for directory" step before environment variable assignment, so that the sanitized branch name can be used when setting the `PUBLIC_URL` and other variables. (`.github/workflows/deploy-test.yml`) [[1]](diffhunk://#diff-3506104a54b3d6803b340621fae99e8ea135690eab9799c489eb239f54587ed7R45-R53) [[2]](diffhunk://#diff-3506104a54b3d6803b340621fae99e8ea135690eab9799c489eb239f54587ed7L57-L65)