### PR TITLE
fix: share game state across screens via GameStateProvider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useReducer, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { HashRouter, Route, Routes } from 'react-router-dom'
 import { ThemeProvider } from 'styled-components'
 import { AnalyticsDashboard } from './components/analytics'
@@ -29,7 +29,7 @@ import { useGamePersistence } from './hooks'
 import * as actions from './state/actions'
 import * as types from './state/actionTypes'
 import * as runAnalytics from './state/analyticsStore'
-import { gameReducer, initialState } from './state/gameReducer'
+import { GameStateProvider, useGameState } from './state/GameStateContext'
 import { GlobalStyles, theme } from './styles'
 import { selectRandomEvent } from './systems/events/events'
 import * as eventsV2 from './systems/eventsV2'
@@ -60,8 +60,8 @@ declare global {
 }
 
 function HelldiversRoguelikeApp() {
-    // --- STATE (Using useReducer for complex state management) ---
-    const [state, dispatch] = useReducer(gameReducer, initialState)
+    // --- STATE (shared via GameStateProvider) ---
+    const { state, dispatch } = useGameState()
 
     // Destructure commonly used state values for easier access
     const {
@@ -129,7 +129,7 @@ function HelldiversRoguelikeApp() {
             // This shouldn't happen (host set their own flag), but clear it anyway
             clearHostDisconnected()
         }
-    }, [hostDisconnected, isHost, wasKicked, clearHostDisconnected])
+    }, [hostDisconnected, isHost, wasKicked, clearHostDisconnected, dispatch])
 
     // Handle client intentional disconnect - return to menu
     useEffect(() => {
@@ -141,7 +141,7 @@ function HelldiversRoguelikeApp() {
             }
             clearClientDisconnected()
         }
-    }, [clientDisconnected, wasKicked, clearClientDisconnected])
+    }, [clientDisconnected, wasKicked, clearClientDisconnected, dispatch])
 
     // Handle being kicked - show kicked screen
     useEffect(() => {
@@ -149,7 +149,7 @@ function HelldiversRoguelikeApp() {
             dispatch(actions.setPhase('KICKED'))
             setMultiplayerMode(null)
         }
-    }, [wasKicked])
+    }, [wasKicked, dispatch])
 
     // UI-only state (not part of game state)
     const [selectedPlayer, setSelectedPlayer] = useState(0) // For custom setup phase
@@ -1870,10 +1870,12 @@ export default function HelldiversRoguelike() {
             <GlobalStyles />
             <HashRouter>
                 <MultiplayerProvider>
-                    <Routes>
-                        <Route path="card-library" element={<CardLibrary />} />
-                        <Route path="/" element={<HelldiversRoguelikeApp />} />
-                    </Routes>
+                    <GameStateProvider>
+                        <Routes>
+                            <Route path="card-library" element={<CardLibrary />} />
+                            <Route path="/" element={<HelldiversRoguelikeApp />} />
+                        </Routes>
+                    </GameStateProvider>
                 </MultiplayerProvider>
             </HashRouter>
         </ThemeProvider>

--- a/src/components/CustomSetup.tsx
+++ b/src/components/CustomSetup.tsx
@@ -1,7 +1,6 @@
-import { useReducer } from 'react'
 import { DIFFICULTY_CONFIG } from 'src/constants/gameConfig'
 import { MASTER_DB } from 'src/data/itemsByWarbond'
-import { gameReducer, initialState } from 'src/state/gameReducer'
+import { useGameState } from 'src/state/GameStateContext'
 import { getFactionColors, SPACING } from 'src/styles'
 import {
     CenteredContent,
@@ -49,7 +48,7 @@ export default function CustomSetup({
     setSelectedPlayer,
     setGameStartTime,
 }: GameLobbyProps): React.ReactElement {
-    const [state, dispatch] = useReducer(gameReducer, initialState)
+    const { state, dispatch } = useGameState()
     const multiplayer = useMultiplayer()
 
     const { customSetup, gameConfig } = state

--- a/src/components/DashboardScreen.tsx
+++ b/src/components/DashboardScreen.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle, XCircle } from 'lucide-react'
-import { useReducer, useState } from 'react'
+import { useState } from 'react'
 import {
     getRequisitionMultiplier,
     getSlotLockCost,
@@ -8,7 +8,7 @@ import {
 } from 'src/constants/balancingConfig'
 import { getMissionsForDifficulty } from 'src/constants/gameConfig'
 import { useGamePersistence } from 'src/hooks'
-import { gameReducer, initialState } from 'src/state/gameReducer'
+import { useGameState } from 'src/state/GameStateContext'
 import { getFactionColors } from 'src/styles'
 import { EVENTS } from 'src/systems/events/events'
 import { useMultiplayer } from 'src/systems/multiplayer'
@@ -92,8 +92,8 @@ export default function DashboardScreen({
     tryTriggerRandomEvent,
     children,
 }: DashboardScreenProps) {
-    // --- STATE (Using useReducer for complex state management) ---
-    const [state, dispatch] = useReducer(gameReducer, initialState)
+    // --- STATE (shared via GameStateProvider) ---
+    const { state, dispatch } = useGameState()
 
     // Destructure commonly used state values for easier access
     const {

--- a/src/components/DraftScreen.tsx
+++ b/src/components/DraftScreen.tsx
@@ -1,7 +1,7 @@
 import { RefreshCw } from 'lucide-react'
-import { useReducer } from 'react'
 import { useGamePersistence } from 'src/hooks'
-import { gameReducer, initialState } from 'src/state/gameReducer'
+import { initialState } from 'src/state/gameReducer'
+import { useGameState } from 'src/state/GameStateContext'
 import { getFactionColors, SPACING } from 'src/styles'
 import {
     ActionButton,
@@ -69,7 +69,7 @@ export default function DraftScreen({
     pendingCardRemoval,
     confirmRemoveCardFromDraft,
 }: DraftScreenProps) {
-    const [state, dispatch] = useReducer(gameReducer, initialState)
+    const { state, dispatch } = useGameState()
 
     const { gameConfig, currentDiff, requisition, players, draftState, draftHistory } = state
 
@@ -198,6 +198,22 @@ export default function DraftScreen({
     }
 
     const player = players[draftState.activePlayerIndex]
+
+    // Guard against missing player data (e.g. state not yet hydrated)
+    if (!player) {
+        return (
+            <PageWrapper>
+                {isMultiplayer && (
+                    <MultiplayerStatusBar gameConfig={gameConfig} onDisconnect={disconnect} />
+                )}
+                <ContentWrapper>
+                    <WaitingMessage>
+                        <WaitingText>Preparing draft…</WaitingText>
+                    </WaitingMessage>
+                </ContentWrapper>
+            </PageWrapper>
+        )
+    }
 
     // In multiplayer, check if it's this player's turn to draft
     const isMyTurn = !isMultiplayer || playerSlot === draftState.activePlayerIndex

--- a/src/components/EventScreen.tsx
+++ b/src/components/EventScreen.tsx
@@ -1,7 +1,6 @@
-import { useReducer } from 'react'
 import { Subfaction } from 'src/constants/balancingConfig'
 import { MASTER_DB } from 'src/data/itemsByWarbond'
-import { gameReducer, initialState } from 'src/state/gameReducer'
+import { useGameState } from 'src/state/GameStateContext'
 import { EventPageWrapper } from 'src/styles/App.styles'
 import {
     applyGainBoosterWithSelection,
@@ -30,7 +29,7 @@ interface EventScreenProps {
 }
 
 export default function EventScreen({ getConnectedPlayerIndices }: EventScreenProps) {
-    const [state, dispatch] = useReducer(gameReducer, initialState)
+    const { state, dispatch } = useGameState()
 
     const {
         gameConfig,

--- a/src/components/SacrificeScreen.tsx
+++ b/src/components/SacrificeScreen.tsx
@@ -1,6 +1,6 @@
-import { useReducer, useState } from 'react'
+import { useState } from 'react'
 import { useGamePersistence } from 'src/hooks'
-import { gameReducer, initialState } from 'src/state/gameReducer'
+import { useGameState } from 'src/state/GameStateContext'
 import { Button, Caption, getFactionColors } from 'src/styles'
 import {
     CenteredContent,
@@ -40,7 +40,7 @@ interface SacrificeScreenProps {
 }
 
 export default function SacrificeScreen({ startDraftPhase }: SacrificeScreenProps) {
-    const [state, dispatch] = useReducer(gameReducer, initialState)
+    const { state, dispatch } = useGameState()
 
     const { gameConfig, players, sacrificeState } = state
 

--- a/src/state/GameStateContext.tsx
+++ b/src/state/GameStateContext.tsx
@@ -1,0 +1,36 @@
+/**
+ * GameStateContext
+ *
+ * Provides a single shared game state reducer across the entire app.
+ * Without this, each screen would create its own private `useReducer`,
+ * leaving them disconnected from the central game state.
+ */
+
+import { createContext, useContext, useReducer } from 'react'
+import { gameReducer, initialState, type GameAction } from './gameReducer'
+import type { GameState } from '../types'
+
+interface GameStateContextValue {
+    state: GameState
+    dispatch: React.Dispatch<GameAction>
+}
+
+const GameStateContext = createContext<GameStateContextValue | null>(null)
+
+export const GameStateProvider = ({ children }: { children: React.ReactNode }) => {
+    const [state, dispatch] = useReducer(gameReducer, initialState)
+
+    return (
+        <GameStateContext.Provider value={{ state, dispatch }}>
+            {children}
+        </GameStateContext.Provider>
+    )
+}
+
+export const useGameState = (): GameStateContextValue => {
+    const context = useContext(GameStateContext)
+    if (!context) {
+        throw new Error('useGameState must be used within a GameStateProvider')
+    }
+    return context
+}


### PR DESCRIPTION
This pull request refactors the app to use a single shared game state across all screens by introducing a `GameStateContext` and replacing local `useReducer` instances with the new context. This ensures consistent state management throughout the app and prevents screens from having disconnected or out-of-sync state. The changes also add a guard to the draft screen to handle cases where player data is not yet available.

**Global State Management Refactor:**

* Introduced `GameStateContext` and `GameStateProvider` in `src/state/GameStateContext.tsx` to provide a shared game state and dispatch function via React context, using the existing `gameReducer` and `initialState`.
* Updated `src/App.tsx` to wrap the app's routes with `GameStateProvider`, ensuring all child components access the shared game state. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L32-R32) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L63-R64) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R1873-R1878)
* Refactored all screens (`CustomSetup`, `DashboardScreen`, `DraftScreen`, `EventScreen`, `SacrificeScreen`) to use the `useGameState` hook instead of their own `useReducer`, ensuring they all read from and update the same state. [[1]](diffhunk://#diff-10af833a1dcdc489424692790d5d0118fed7afb5a839ae5c29789b7f457d69a4L1-R3) [[2]](diffhunk://#diff-10af833a1dcdc489424692790d5d0118fed7afb5a839ae5c29789b7f457d69a4L52-R51) [[3]](diffhunk://#diff-606803d52c19fbe1c3d87146dcf7080e99e4509cf666600ecd9e961b77af1155L2-R2) [[4]](diffhunk://#diff-606803d52c19fbe1c3d87146dcf7080e99e4509cf666600ecd9e961b77af1155L11-R11) [[5]](diffhunk://#diff-606803d52c19fbe1c3d87146dcf7080e99e4509cf666600ecd9e961b77af1155L95-R96) [[6]](diffhunk://#diff-8a2732f62ed7991569af41ffa3a9b0e83d29b639768edd8f3cecb137dcde79a4L2-R4) [[7]](diffhunk://#diff-8a2732f62ed7991569af41ffa3a9b0e83d29b639768edd8f3cecb137dcde79a4L72-R72) [[8]](diffhunk://#diff-e2a2587eae17965a3a899fd2d1bb7ca68bbda7febe8d98088c4860d38088824aL1-R3) [[9]](diffhunk://#diff-e2a2587eae17965a3a899fd2d1bb7ca68bbda7febe8d98088c4860d38088824aL33-R32) [[10]](diffhunk://#diff-879dd1e72a5c1d0898615ce3bf6b70d0861b424e46c1781058ef67f0e7569b02L1-R3) [[11]](diffhunk://#diff-879dd1e72a5c1d0898615ce3bf6b70d0861b424e46c1781058ef67f0e7569b02L43-R43)

**Bug Fixes and Improvements:**

* Added a guard in `DraftScreen` to display a waiting message if player data is not yet hydrated, preventing errors during state initialization.
* Updated effect dependencies in `App.tsx` to include `dispatch`, ensuring correct behavior when dispatch changes. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L132-R132) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L144-R152)